### PR TITLE
Add project URL loading support

### DIFF
--- a/src/components/menu-bar/menu-bar.jsx
+++ b/src/components/menu-bar/menu-bar.jsx
@@ -187,6 +187,7 @@ class MenuBar extends React.Component {
             'handleSetMode',
             'handleKeyPress',
             'handleRestoreOption',
+            'handleClickLoadFromUrl',
             'getSaveToComputerHandler',
             'restoreOptionMessage'
         ]);
@@ -223,6 +224,14 @@ class MenuBar extends React.Component {
     handleClickSaveAsCopy () {
         this.props.onClickSaveAsCopy();
         this.props.onRequestCloseFile();
+    }
+    handleClickLoadFromUrl () {
+        if (!this.props.onStartLoadingProjectUrl) {
+            return;
+        }
+        const promptMessage = this.props.intl.formatMessage(sharedMessages.loadFromUrlPrompt);
+        const projectUrl = prompt(promptMessage); // eslint-disable-line no-alert
+        this.props.onStartLoadingProjectUrl(projectUrl);
     }
     handleClickSeeCommunity (waitForUpdate) {
         if (this.props.shouldSaveBeforeTransition()) {
@@ -504,6 +513,11 @@ class MenuBar extends React.Component {
                                             onClick={this.props.onStartSelectingFileUpload}
                                         >
                                             {this.props.intl.formatMessage(sharedMessages.loadFromComputerTitle)}
+                                        </MenuItem>
+                                        <MenuItem
+                                            onClick={this.handleClickLoadFromUrl}
+                                        >
+                                            {this.props.intl.formatMessage(sharedMessages.loadFromUrlTitle)}
                                         </MenuItem>
                                         <SB3Downloader>{(className, downloadProjectCallback) => (
                                             <MenuItem
@@ -934,6 +948,7 @@ MenuBar.propTypes = {
     onSeeCommunity: PropTypes.func,
     onSetTimeTravelMode: PropTypes.func,
     onShare: PropTypes.func,
+    onStartLoadingProjectUrl: PropTypes.func,
     onStartSelectingFileUpload: PropTypes.func,
     onToggleLoginOpen: PropTypes.func,
     projectTitle: PropTypes.string,

--- a/src/lib/sb-file-uploader-hoc.jsx
+++ b/src/lib/sb-file-uploader-hoc.jsx
@@ -22,6 +22,11 @@ import {
     closeFileMenu
 } from '../reducers/menus';
 
+const UploadSources = {
+    FILE: 'file',
+    URL: 'url'
+};
+
 const messages = defineMessages({
     loadError: {
         id: 'gui.projectLoader.loadError',
@@ -47,11 +52,14 @@ const SBFileUploaderHOC = function (WrappedComponent) {
                 'createFileObjects',
                 'getProjectTitleFromFilename',
                 'handleFinishedLoadingUpload',
+                'handleStartLoadingProjectUrl',
                 'handleStartSelectingFileUpload',
                 'handleChange',
                 'onload',
                 'removeFileObjects'
             ]);
+            this.uploadSource = null;
+            this.projectUrlToUpload = null;
         }
         componentDidUpdate (prevProps) {
             if (this.props.isLoadingUpload && !prevProps.isLoadingUpload) {
@@ -64,6 +72,38 @@ const SBFileUploaderHOC = function (WrappedComponent) {
         // step 1: this is where the upload process begins
         handleStartSelectingFileUpload () {
             this.createFileObjects(); // go to step 2
+        }
+        handleStartLoadingProjectUrl (url) {
+            const {
+                intl,
+                isShowingWithoutId,
+                loadingState,
+                projectChanged,
+                userOwnsProject
+            } = this.props;
+            const trimmedUrl = typeof url === 'string' ? url.trim() : '';
+            if (!trimmedUrl) {
+                this.removeFileObjects();
+                this.props.closeFileMenu();
+                return;
+            }
+
+            let uploadAllowed = true;
+            if (userOwnsProject || (projectChanged && isShowingWithoutId)) {
+                uploadAllowed = confirm( // eslint-disable-line no-alert
+                    intl.formatMessage(sharedMessages.replaceProjectWarning)
+                );
+            }
+            if (uploadAllowed) {
+                this.removeFileObjects();
+                this.projectUrlToUpload = trimmedUrl;
+                this.uploadSource = UploadSources.URL;
+                this.fileToUpload = null;
+                this.props.requestProjectUpload(loadingState);
+            } else {
+                this.removeFileObjects();
+            }
+            this.props.closeFileMenu();
         }
         // step 2: create a FileReader and an <input> element, and issue a
         // pseudo-click to it. That will open the file chooser dialog.
@@ -97,6 +137,8 @@ const SBFileUploaderHOC = function (WrappedComponent) {
             const thisFileInput = e.target;
             if (thisFileInput.files) { // Don't attempt to load if no file was selected
                 this.fileToUpload = thisFileInput.files[0];
+                this.projectUrlToUpload = null;
+                this.uploadSource = UploadSources.FILE;
 
                 // If user owns the project, or user has changed the project,
                 // we must confirm with the user that they really intend to
@@ -123,6 +165,45 @@ const SBFileUploaderHOC = function (WrappedComponent) {
         // step 5: called from componentDidUpdate when project state shows
         // that project data has finished "uploading" into the browser
         handleFinishedLoadingUpload () {
+            if (this.uploadSource === UploadSources.URL) {
+                const projectUrl = this.projectUrlToUpload;
+                if (projectUrl) {
+                    this.props.onLoadingStarted();
+                    let loadingSuccess = false;
+                    const urlParts = projectUrl.split('/');
+                    const lastPart = urlParts[urlParts.length - 1];
+                    const urlFilename = lastPart ? lastPart.split(/[?#]/)[0] : '';
+                    return fetch(projectUrl)
+                        .then(response => {
+                            if (!response.ok) {
+                                const statusMessage = `${response.status} ${response.statusText}`;
+                                throw new Error(`Unable to fetch project from URL: ${statusMessage}`);
+                            }
+                            return response.arrayBuffer();
+                        })
+                        .then(arrayBuffer => this.props.vm.loadProject(arrayBuffer))
+                        .then(() => {
+                            if (urlFilename) {
+                                const uploadedProjectTitle = this.getProjectTitleFromFilename(urlFilename);
+                                if (uploadedProjectTitle) {
+                                    this.props.onSetProjectTitle(uploadedProjectTitle);
+                                }
+                            }
+                            loadingSuccess = true;
+                        })
+                        .catch(error => {
+                            log.warn(error);
+                            alert(this.props.intl.formatMessage(messages.loadError)); // eslint-disable-line no-alert
+                        })
+                        .then(() => {
+                            this.props.onLoadingFinished(this.props.loadingState, loadingSuccess);
+                            this.removeFileObjects();
+                        });
+                }
+                this.props.cancelFileUpload(this.props.loadingState);
+                this.removeFileObjects();
+                return;
+            }
             if (this.fileToUpload && this.fileReader) {
                 // begin to read data from the file. When finished,
                 // cues step 6 using the reader's onload callback
@@ -179,6 +260,8 @@ const SBFileUploaderHOC = function (WrappedComponent) {
             this.inputElement = null;
             this.fileReader = null;
             this.fileToUpload = null;
+            this.projectUrlToUpload = null;
+            this.uploadSource = null;
         }
         render () {
             const {
@@ -201,6 +284,7 @@ const SBFileUploaderHOC = function (WrappedComponent) {
                 <React.Fragment>
                     <WrappedComponent
                         onStartSelectingFileUpload={this.handleStartSelectingFileUpload}
+                        onStartLoadingProjectUrl={this.handleStartLoadingProjectUrl}
                         {...componentProps}
                     />
                 </React.Fragment>

--- a/src/lib/shared-messages.js
+++ b/src/lib/shared-messages.js
@@ -30,5 +30,15 @@ export default defineMessages({
         id: 'gui.sharedMessages.loadFromComputerTitle',
         defaultMessage: 'Load from your computer',
         description: 'Title for uploading a project from your computer'
+    },
+    loadFromUrlTitle: {
+        id: 'gui.sharedMessages.loadFromUrlTitle',
+        defaultMessage: 'Load from URL',
+        description: 'Title for uploading a project from a URL'
+    },
+    loadFromUrlPrompt: {
+        id: 'gui.sharedMessages.loadFromUrlPrompt',
+        defaultMessage: 'Enter the URL of the project',
+        description: 'Prompt asking the user for a project URL to load'
     }
 });

--- a/test/unit/util/sb-file-uploader-hoc.test.jsx
+++ b/test/unit/util/sb-file-uploader-hoc.test.jsx
@@ -12,6 +12,8 @@ describe('SBFileUploaderHOC', () => {
     const mockStore = configureStore();
     let store;
     let vm;
+    let originalFetch;
+    let originalAlert;
 
     // Wrap this in a function so it gets test specific states and can be reused.
     const getContainer = function () {
@@ -37,7 +39,7 @@ describe('SBFileUploaderHOC', () => {
                 vm={vm}
                 onLoadingFinished={jest.fn()}
                 onLoadingStarted={jest.fn()}
-                onUpdateProjectTitle={jest.fn()}
+                onSetProjectTitle={jest.fn()}
             />
         );
         return wrapper
@@ -45,6 +47,52 @@ describe('SBFileUploaderHOC', () => {
             .dive() // unwrap redux Connect(SBFileUploaderComponent)
             .instance(); // SBFileUploaderComponent
     };
+
+    const createUploader = (props = {}) => {
+        const WrappedComponent = getContainer();
+        const defaultProps = {
+            canSave: false,
+            cancelFileUpload: jest.fn(),
+            closeFileMenu: jest.fn(),
+            loadingState: LoadingState.SHOWING_WITHOUT_ID,
+            onLoadingFinished: jest.fn(),
+            onLoadingStarted: jest.fn(),
+            onSetProjectTitle: jest.fn(),
+            projectChanged: false,
+            requestProjectUpload: jest.fn(),
+            userOwnsProject: false,
+            vm: {
+                loadProject: jest.fn(() => Promise.resolve())
+            }
+        };
+        const wrapper = shallowMountWithContext(
+            <WrappedComponent
+                {...defaultProps}
+                {...props}
+            />
+        );
+        const componentWrapper = wrapper
+            .dive() // unwrap intl
+            .dive(); // unwrap redux Connect(SBFileUploaderComponent)
+        return {
+            wrapper: componentWrapper,
+            instance: componentWrapper.instance(),
+            props: componentWrapper.props(),
+            providedProps: {...defaultProps, ...props}
+        };
+    };
+
+    const flushPromises = () => new Promise(resolve => setImmediate(resolve));
+
+    beforeAll(() => {
+        originalFetch = global.fetch;
+        originalAlert = global.alert;
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        global.alert = originalAlert;
+    });
 
     beforeEach(() => {
         vm = new VM();
@@ -97,12 +145,109 @@ describe('SBFileUploaderHOC', () => {
                 vm={vm}
                 onLoadingFinished={jest.fn()}
                 onLoadingStarted={jest.fn()}
-                onUpdateProjectTitle={jest.fn()}
+                onSetProjectTitle={jest.fn()}
             />
         );
         mounted.setProps({
             isLoadingUpload: true
         });
         expect(mockedCancelFileUpload).toHaveBeenCalled();
+    });
+
+    test('handleStartLoadingProjectUrl triggers upload request', () => {
+        const requestProjectUpload = jest.fn();
+        const closeFileMenu = jest.fn();
+        const {instance} = createUploader({
+            projectChanged: false,
+            requestProjectUpload,
+            closeFileMenu
+        });
+
+        instance.handleStartLoadingProjectUrl('https://example.com/project.sb3');
+
+        expect(instance.projectUrlToUpload).toBe('https://example.com/project.sb3');
+        expect(instance.uploadSource).toBe('url');
+        expect(requestProjectUpload).toHaveBeenCalledWith(instance.props.loadingState);
+        expect(closeFileMenu).toHaveBeenCalled();
+    });
+
+    test('removeFileObjects clears url state', () => {
+        const {instance} = createUploader();
+        instance.projectUrlToUpload = 'https://example.com/project.sb3';
+        instance.uploadSource = 'url';
+
+        instance.removeFileObjects();
+
+        expect(instance.projectUrlToUpload).toBeNull();
+        expect(instance.uploadSource).toBeNull();
+    });
+
+    test('handleFinishedLoadingUpload loads project from url', async () => {
+        const arrayBuffer = new ArrayBuffer(8);
+        const loadProject = jest.fn(() => Promise.resolve());
+        const onLoadingStarted = jest.fn();
+        const onLoadingFinished = jest.fn();
+        const onSetProjectTitle = jest.fn();
+        const {instance} = createUploader({
+            onLoadingFinished,
+            onLoadingStarted,
+            onSetProjectTitle,
+            vm: {loadProject}
+        });
+        const originalRemoveFileObjects = instance.removeFileObjects;
+        const removeFileObjectsSpy = jest.fn(() => originalRemoveFileObjects.call(instance));
+        instance.removeFileObjects = removeFileObjectsSpy;
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            arrayBuffer: () => Promise.resolve(arrayBuffer)
+        }));
+        global.alert = jest.fn();
+
+        instance.uploadSource = 'url';
+        instance.projectUrlToUpload = 'https://example.com/project.sb3?download=1';
+
+        await instance.handleFinishedLoadingUpload();
+        await flushPromises();
+
+        expect(global.fetch).toHaveBeenCalledWith('https://example.com/project.sb3?download=1');
+        expect(onLoadingStarted).toHaveBeenCalled();
+        expect(loadProject).toHaveBeenCalledWith(arrayBuffer);
+        expect(onSetProjectTitle).toHaveBeenCalledWith('project');
+        expect(onLoadingFinished).toHaveBeenCalledWith(instance.props.loadingState, true);
+        expect(global.alert).not.toHaveBeenCalled();
+        expect(removeFileObjectsSpy).toHaveBeenCalled();
+    });
+
+    test('handleFinishedLoadingUpload handles url load errors', async () => {
+        const loadProject = jest.fn(() => Promise.reject(new Error('failed')));
+        const onLoadingFinished = jest.fn();
+        const onLoadingStarted = jest.fn();
+        const {instance} = createUploader({
+            onLoadingFinished,
+            onLoadingStarted,
+            vm: {loadProject}
+        });
+        const originalRemoveFileObjects = instance.removeFileObjects;
+        const removeFileObjectsSpy = jest.fn(() => originalRemoveFileObjects.call(instance));
+        instance.removeFileObjects = removeFileObjectsSpy;
+
+        global.fetch = jest.fn(() => Promise.resolve({
+            ok: true,
+            arrayBuffer: () => Promise.resolve(new ArrayBuffer(4))
+        }));
+        global.alert = jest.fn();
+
+        instance.uploadSource = 'url';
+        instance.projectUrlToUpload = 'https://example.com/error.sb3';
+
+        await instance.handleFinishedLoadingUpload();
+        await flushPromises();
+
+        expect(onLoadingStarted).toHaveBeenCalled();
+        expect(loadProject).toHaveBeenCalled();
+        expect(global.alert).toHaveBeenCalled();
+        expect(onLoadingFinished).toHaveBeenCalledWith(instance.props.loadingState, false);
+        expect(removeFileObjectsSpy).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
- allow the SB file uploader HOC to fetch and load projects from a URL in addition to local files
- expose a new handler to the menu bar and add a "Load from URL" menu item with localized messaging
- cover the URL upload flow with unit tests, including cleanup of URL-specific state

## Testing
- npx jest test/unit/util/sb-file-uploader-hoc.test.jsx

------
https://chatgpt.com/codex/tasks/task_e_68cc00ba28208333aa03eb6b7013bed9